### PR TITLE
Added support for miscellaneous icons by using default icon name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const WeatherIcon = (props) => {
 };
 
 WeatherIcon.propTypes = {
-  name: PropTypes.oneOf(['owm', 'darksky', 'yahoo']).isRequired,
+  name: PropTypes.oneOf(['def', 'owm', 'darksky', 'yahoo']).isRequired,
   className: PropTypes.string,
   iconId: PropTypes.string.isRequired,
   flip: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,14 @@
-import { owmIcons, yahooIcons, darkSkyIcons } from './maps';
+import { defaultIcons, owmIcons, yahooIcons, darkSkyIcons } from './maps';
 
 
 var helper = (function() {
+  var convertDefaultCode = function(id) {
+    if(defaultIcons[id]) {
+      let prefix = 'wi wi-';
+      return prefix + defaultIcons[id].icon;
+    }
+    throw new Error('ID passed to component invalid');
+  };
   var convertDarkSkyCode = function(id) {
     if(darkSkyIcons[id]) {
       return darkSkyIcons[id].icon;
@@ -32,6 +39,8 @@ var helper = (function() {
 
   var convertCode = function(name, id) {
     switch(name) {
+      case 'def':
+        return convertDefaultCode(id);
       case 'owm':
         return convertOWMCode(id);
       case 'darksky':

--- a/src/utils/maps/default-weather-icons.json
+++ b/src/utils/maps/default-weather-icons.json
@@ -1,0 +1,1251 @@
+{
+  "day-sunny": {
+    "label": "day-sunny",
+    "icon": "day-sunny"
+  },
+
+  "day-cloudy": {
+    "label": "day-cloudy",
+    "icon": "day-cloudy"
+  },
+
+  "day-cloudy-gusts": {
+    "label": "day-cloudy-gusts",
+    "icon": "day-cloudy-gusts"
+  },
+
+  "day-cloudy-windy": {
+    "label": "day-cloudy-windy",
+    "icon": "day-cloudy-windy"
+  },
+
+  "day-fog": {
+    "label": "day-fog",
+    "icon": "day-fog"
+  },
+
+  "day-hail": {
+    "label": "day-hail",
+    "icon": "day-hail"
+  },
+
+  "day-haze": {
+    "label": "day-haze",
+    "icon": "day-haze"
+  },
+
+  "day-lightning": {
+    "label": "day-lightning",
+    "icon": "day-lightning"
+  },
+
+  "day-rain": {
+    "label": "day-rain",
+    "icon": "day-rain"
+  },
+
+  "day-rain-mix": {
+    "label": "day-rain-mix",
+    "icon": "day-rain-mix"
+  },
+
+  "day-rain-wind": {
+    "label": "day-rain-wind",
+    "icon": "day-rain-wind"
+  },
+
+  "day-showers": {
+    "label": "day-showers",
+    "icon": "day-showers"
+  },
+
+  "day-sleet": {
+    "label": "day-sleet",
+    "icon": "day-sleet"
+  },
+
+  "day-sleet-storm": {
+    "label": "day-sleet-storm",
+    "icon": "day-sleet-storm"
+  },
+
+  "day-snow": {
+    "label": "day-snow",
+    "icon": "day-snow"
+  },
+
+  "day-snow-thunderstorm": {
+    "label": "day-snow-thunderstorm",
+    "icon": "day-snow-thunderstorm"
+  },
+
+  "day-snow-wind": {
+    "label": "day-snow-wind",
+    "icon": "day-snow-wind"
+  },
+
+  "day-sprinkle": {
+    "label": "day-sprinkle",
+    "icon": "day-sprinkle"
+  },
+
+  "day-storm-showers": {
+    "label": "day-storm-showers",
+    "icon": "day-storm-showers"
+  },
+
+  "day-sunny-overcast": {
+    "label": "day-sunny-overcast",
+    "icon": "day-sunny-overcast"
+  },
+
+  "day-thunderstorm": {
+    "label": "day-thunderstorm",
+    "icon": "day-thunderstorm"
+  },
+
+  "day-windy": {
+    "label": "day-windy",
+    "icon": "day-windy"
+  },
+
+  "solar-eclipse": {
+    "label": "solar-eclipse",
+    "icon": "solar-eclipse"
+  },
+
+  "hot": {
+    "label": "hot",
+    "icon": "hot"
+  },
+
+  "day-cloudy-high": {
+    "label": "day-cloudy-high",
+    "icon": "day-cloudy-high"
+  },
+
+  "day-light-wind": {
+    "label": "day-light-wind",
+    "icon": "day-light-wind"
+  },
+
+  "night-clear": {
+    "label": "night-clear",
+    "icon": "night-clear"
+  },
+
+  "night-alt-cloudy": {
+    "label": "night-alt-cloudy",
+    "icon": "night-alt-cloudy"
+  },
+
+  "night-alt-cloudy-gusts": {
+    "label": "night-alt-cloudy-gusts",
+    "icon": "night-alt-cloudy-gusts"
+  },
+
+  "night-alt-cloudy-windy": {
+    "label": "night-alt-cloudy-windy",
+    "icon": "night-alt-cloudy-windy"
+  },
+
+  "night-alt-hail": {
+    "label": "night-alt-hail",
+    "icon": "night-alt-hail"
+  },
+
+  "night-alt-lightning": {
+    "label": "night-alt-lightning",
+    "icon": "night-alt-lightning"
+  },
+
+  "night-alt-rain": {
+    "label": "night-alt-rain",
+    "icon": "night-alt-rain"
+  },
+
+  "night-alt-rain-mix": {
+    "label": "night-alt-rain-mix",
+    "icon": "night-alt-rain-mix"
+  },
+
+  "night-alt-rain-wind": {
+    "label": "night-alt-rain-wind",
+    "icon": "night-alt-rain-wind"
+  },
+
+  "night-alt-showers": {
+    "label": "night-alt-showers",
+    "icon": "night-alt-showers"
+  },
+
+  "night-alt-sleet": {
+    "label": "night-alt-sleet",
+    "icon": "night-alt-sleet"
+  },
+
+  "night-alt-sleet-storm": {
+    "label": "night-alt-sleet-storm",
+    "icon": "night-alt-sleet-storm"
+  },
+
+  "night-alt-snow": {
+    "label": "night-alt-snow",
+    "icon": "night-alt-snow"
+  },
+
+  "night-alt-snow-thunderstorm": {
+    "label": "night-alt-snow-thunderstorm",
+    "icon": "night-alt-snow-thunderstorm"
+  },
+
+  "night-alt-snow-wind": {
+    "label": "night-alt-snow-wind",
+    "icon": "night-alt-snow-wind"
+  },
+
+  "night-alt-sprinkle": {
+    "label": "night-alt-sprinkle",
+    "icon": "night-alt-sprinkle"
+  },
+
+  "night-alt-storm-showers": {
+    "label": "night-alt-storm-showers",
+    "icon": "night-alt-storm-showers"
+  },
+
+  "night-alt-thunderstorm": {
+    "label": "night-alt-thunderstorm",
+    "icon": "night-alt-thunderstorm"
+  },
+
+  "night-cloudy": {
+    "label": "night-cloudy",
+    "icon": "night-cloudy"
+  },
+
+  "night-cloudy-gusts": {
+    "label": "night-cloudy-gusts",
+    "icon": "night-cloudy-gusts"
+  },
+
+  "night-cloudy-windy": {
+    "label": "night-cloudy-windy",
+    "icon": "night-cloudy-windy"
+  },
+
+  "night-fog": {
+    "label": "night-fog",
+    "icon": "night-fog"
+  },
+
+  "night-hail": {
+    "label": "night-hail",
+    "icon": "night-hail"
+  },
+
+  "night-lightning": {
+    "label": "night-lightning",
+    "icon": "night-lightning"
+  },
+
+  "night-partly-cloudy": {
+    "label": "night-partly-cloudy",
+    "icon": "night-partly-cloudy"
+  },
+
+  "night-rain": {
+    "label": "night-rain",
+    "icon": "night-rain"
+  },
+
+  "night-rain-mix": {
+    "label": "night-rain-mix",
+    "icon": "night-rain-mix"
+  },
+
+  "night-rain-wind": {
+    "label": "night-rain-wind",
+    "icon": "night-rain-wind"
+  },
+
+  "night-showers": {
+    "label": "night-showers",
+    "icon": "night-showers"
+  },
+
+  "night-sleet": {
+    "label": "night-sleet",
+    "icon": "night-sleet"
+  },
+
+  "night-sleet-storm": {
+    "label": "night-sleet-storm",
+    "icon": "night-sleet-storm"
+  },
+
+  "night-snow": {
+    "label": "night-snow",
+    "icon": "night-snow"
+  },
+
+  "night-snow-thunderstorm": {
+    "label": "night-snow-thunderstorm",
+    "icon": "night-snow-thunderstorm"
+  },
+
+  "night-snow-wind": {
+    "label": "night-snow-wind",
+    "icon": "night-snow-wind"
+  },
+
+  "night-sprinkle": {
+    "label": "night-sprinkle",
+    "icon": "night-sprinkle"
+  },
+
+  "night-storm-showers": {
+    "label": "night-storm-showers",
+    "icon": "night-storm-showers"
+  },
+
+  "night-thunderstorm": {
+    "label": "night-thunderstorm",
+    "icon": "night-thunderstorm"
+  },
+
+  "lunar-eclipse": {
+    "label": "lunar-eclipse",
+    "icon": "lunar-eclipse"
+  },
+
+  "stars": {
+    "label": "stars",
+    "icon": "stars"
+  },
+
+  "storm-showers": {
+    "label": "storm-showers",
+    "icon": "storm-showers"
+  },
+
+  "thunderstorm": {
+    "label": "thunderstorm",
+    "icon": "thunderstorm"
+  },
+
+  "night-alt-cloudy-high": {
+    "label": "night-alt-cloudy-high",
+    "icon": "night-alt-cloudy-high"
+  },
+
+  "night-cloudy-high": {
+    "label": "night-cloudy-high",
+    "icon": "night-cloudy-high"
+  },
+
+  "night-alt-partly-cloudy": {
+    "label": "night-alt-partly-cloudy",
+    "icon": "night-alt-partly-cloudy"
+  },
+
+  "cloud": {
+    "label": "cloud",
+    "icon": "cloud"
+  },
+
+  "cloudy": {
+    "label": "cloudy",
+    "icon": "cloudy"
+  },
+
+  "cloudy-gusts": {
+    "label": "cloudy-gusts",
+    "icon": "cloudy-gusts"
+  },
+
+  "cloudy-windy": {
+    "label": "cloudy-windy",
+    "icon": "cloudy-windy"
+  },
+
+  "fog": {
+    "label": "fog",
+    "icon": "fog"
+  },
+
+  "hail": {
+    "label": "hail",
+    "icon": "hail"
+  },
+
+  "rain": {
+    "label": "rain",
+    "icon": "rain"
+  },
+
+  "rain-mix": {
+    "label": "rain-mix",
+    "icon": "rain-mix"
+  },
+
+  "rain-wind": {
+    "label": "rain-wind",
+    "icon": "rain-wind"
+  },
+
+  "showers": {
+    "label": "showers",
+    "icon": "showers"
+  },
+
+  "sleet": {
+    "label": "sleet",
+    "icon": "sleet"
+  },
+
+  "snow": {
+    "label": "snow",
+    "icon": "snow"
+  },
+
+  "sprinkle": {
+    "label": "sprinkle",
+    "icon": "sprinkle"
+  },
+
+  "storm-showers": {
+    "label": "storm-showers",
+    "icon": "storm-showers"
+  },
+
+  "thunderstorm": {
+    "label": "thunderstorm",
+    "icon": "thunderstorm"
+  },
+
+  "snow-wind": {
+    "label": "snow-wind",
+    "icon": "snow-wind"
+  },
+
+  "snow": {
+    "label": "snow",
+    "icon": "snow"
+  },
+
+  "smog": {
+    "label": "smog",
+    "icon": "smog"
+  },
+
+  "smoke": {
+    "label": "smoke",
+    "icon": "smoke"
+  },
+
+  "lightning": {
+    "label": "lightning",
+    "icon": "lightning"
+  },
+
+  "raindrops": {
+    "label": "raindrops",
+    "icon": "raindrops"
+  },
+
+  "raindrop": {
+    "label": "raindrop",
+    "icon": "raindrop"
+  },
+
+  "dust": {
+    "label": "dust",
+    "icon": "dust"
+  },
+
+  "snowflake-cold": {
+    "label": "snowflake-cold",
+    "icon": "snowflake-cold"
+  },
+
+  "windy": {
+    "label": "windy",
+    "icon": "windy"
+  },
+
+  "strong-wind": {
+    "label": "strong-wind",
+    "icon": "strong-wind"
+  },
+
+  "sandstorm": {
+    "label": "sandstorm",
+    "icon": "sandstorm"
+  },
+
+  "earthquake": {
+    "label": "earthquake",
+    "icon": "earthquake"
+  },
+
+  "fire": {
+    "label": "fire",
+    "icon": "fire"
+  },
+
+  "flood": {
+    "label": "flood",
+    "icon": "flood"
+  },
+
+  "meteor": {
+    "label": "meteor",
+    "icon": "meteor"
+  },
+
+  "tsunami": {
+    "label": "tsunami",
+    "icon": "tsunami"
+  },
+
+  "volcano": {
+    "label": "volcano",
+    "icon": "volcano"
+  },
+
+  "hurricane": {
+    "label": "hurricane",
+    "icon": "hurricane"
+  },
+
+  "tornado": {
+    "label": "tornado",
+    "icon": "tornado"
+  },
+
+  "small-craft-advisory": {
+    "label": "small-craft-advisory",
+    "icon": "small-craft-advisory"
+  },
+
+  "gale-warning": {
+    "label": "gale-warning",
+    "icon": "gale-warning"
+  },
+
+  "storm-warning": {
+    "label": "storm-warning",
+    "icon": "storm-warning"
+  },
+
+  "hurricane-warning": {
+    "label": "hurricane-warning",
+    "icon": "hurricane-warning"
+  },
+
+  "wind-direction": {
+    "label": "wind-direction",
+    "icon": "wind-direction"
+  },
+
+  "alien": {
+    "label": "alien",
+    "icon": "alien"
+  },
+
+  "celsius": {
+    "label": "celsius",
+    "icon": "celsius"
+  },
+
+  "fahrenheit": {
+    "label": "fahrenheit",
+    "icon": "fahrenheit"
+  },
+
+  "degrees": {
+    "label": "degrees",
+    "icon": "degrees"
+  },
+
+  "thermometer": {
+    "label": "thermometer",
+    "icon": "thermometer"
+  },
+
+  "thermometer-exterior": {
+    "label": "thermometer-exterior",
+    "icon": "thermometer-exterior"
+  },
+
+  "thermometer-internal": {
+    "label": "thermometer-internal",
+    "icon": "thermometer-internal"
+  },
+
+  "cloud-down": {
+    "label": "cloud-down",
+    "icon": "cloud-down"
+  },
+
+  "cloud-up": {
+    "label": "cloud-up",
+    "icon": "cloud-up"
+  },
+
+  "cloud-refresh": {
+    "label": "cloud-refresh",
+    "icon": "cloud-refresh"
+  },
+
+  "horizon": {
+    "label": "horizon",
+    "icon": "horizon"
+  },
+
+  "horizon-alt": {
+    "label": "horizon-alt",
+    "icon": "horizon-alt"
+  },
+
+  "sunrise": {
+    "label": "sunrise",
+    "icon": "sunrise"
+  },
+
+  "sunset": {
+    "label": "sunset",
+    "icon": "sunset"
+  },
+
+  "moonrise": {
+    "label": "moonrise",
+    "icon": "moonrise"
+  },
+
+  "moonset": {
+    "label": "moonset",
+    "icon": "moonset"
+  },
+
+  "refresh": {
+    "label": "refresh",
+    "icon": "refresh"
+  },
+
+  "refresh-alt": {
+    "label": "refresh-alt",
+    "icon": "refresh-alt"
+  },
+
+  "umbrella": {
+    "label": "umbrella",
+    "icon": "umbrella"
+  },
+
+  "barometer": {
+    "label": "barometer",
+    "icon": "barometer"
+  },
+
+  "humidity": {
+    "label": "humidity",
+    "icon": "humidity"
+  },
+
+  "na": {
+    "label": "na",
+    "icon": "na"
+  },
+
+  "train": {
+    "label": "train",
+    "icon": "train"
+  },
+
+  "moon-new": {
+    "label": "moon-new",
+    "icon": "moon-new"
+  },
+
+  "moon-waxing-crescent-1": {
+    "label": "moon-waxing-crescent-1",
+    "icon": "moon-waxing-crescent-1"
+  },
+
+  "moon-waxing-crescent-2": {
+    "label": "moon-waxing-crescent-2",
+    "icon": "moon-waxing-crescent-2"
+  },
+
+  "moon-waxing-crescent-3": {
+    "label": "moon-waxing-crescent-3",
+    "icon": "moon-waxing-crescent-3"
+  },
+
+  "moon-waxing-crescent-4": {
+    "label": "moon-waxing-crescent-4",
+    "icon": "moon-waxing-crescent-4"
+  },
+
+  "moon-waxing-crescent-5": {
+    "label": "moon-waxing-crescent-5",
+    "icon": "moon-waxing-crescent-5"
+  },
+
+  "moon-waxing-crescent-6": {
+    "label": "moon-waxing-crescent-6",
+    "icon": "moon-waxing-crescent-6"
+  },
+
+  "moon-first-quarter": {
+    "label": "moon-first-quarter",
+    "icon": "moon-first-quarter"
+  },
+
+  "moon-waxing-gibbous-1": {
+    "label": "moon-waxing-gibbous-1",
+    "icon": "moon-waxing-gibbous-1"
+  },
+
+  "moon-waxing-gibbous-2": {
+    "label": "moon-waxing-gibbous-2",
+    "icon": "moon-waxing-gibbous-2"
+  },
+
+  "moon-waxing-gibbous-3": {
+    "label": "moon-waxing-gibbous-3",
+    "icon": "moon-waxing-gibbous-3"
+  },
+
+  "moon-waxing-gibbous-4": {
+    "label": "moon-waxing-gibbous-4",
+    "icon": "moon-waxing-gibbous-4"
+  },
+
+  "moon-waxing-gibbous-5": {
+    "label": "moon-waxing-gibbous-5",
+    "icon": "moon-waxing-gibbous-5"
+  },
+
+  "moon-waxing-gibbous-6": {
+    "label": "moon-waxing-gibbous-6",
+    "icon": "moon-waxing-gibbous-6"
+  },
+
+  "moon-full": {
+    "label": "moon-full",
+    "icon": "moon-full"
+  },
+
+  "moon-waning-gibbous-1": {
+    "label": "moon-waning-gibbous-1",
+    "icon": "moon-waning-gibbous-1"
+  },
+
+  "moon-waning-gibbous-2": {
+    "label": "moon-waning-gibbous-2",
+    "icon": "moon-waning-gibbous-2"
+  },
+
+  "moon-waning-gibbous-3": {
+    "label": "moon-waning-gibbous-3",
+    "icon": "moon-waning-gibbous-3"
+  },
+
+  "moon-waning-gibbous-4": {
+    "label": "moon-waning-gibbous-4",
+    "icon": "moon-waning-gibbous-4"
+  },
+
+  "moon-waning-gibbous-5": {
+    "label": "moon-waning-gibbous-5",
+    "icon": "moon-waning-gibbous-5"
+  },
+
+  "moon-waning-gibbous-6": {
+    "label": "moon-waning-gibbous-6",
+    "icon": "moon-waning-gibbous-6"
+  },
+
+  "moon-third-quarter": {
+    "label": "moon-third-quarter",
+    "icon": "moon-third-quarter"
+  },
+
+  "moon-waning-crescent-1": {
+    "label": "moon-waning-crescent-1",
+    "icon": "moon-waning-crescent-1"
+  },
+
+  "moon-waning-crescent-2": {
+    "label": "moon-waning-crescent-2",
+    "icon": "moon-waning-crescent-2"
+  },
+
+  "moon-waning-crescent-3": {
+    "label": "moon-waning-crescent-3",
+    "icon": "moon-waning-crescent-3"
+  },
+
+  "moon-waning-crescent-4": {
+    "label": "moon-waning-crescent-4",
+    "icon": "moon-waning-crescent-4"
+  },
+
+  "moon-waning-crescent-5": {
+    "label": "moon-waning-crescent-5",
+    "icon": "moon-waning-crescent-5"
+  },
+
+  "moon-waning-crescent-6": {
+    "label": "moon-waning-crescent-6",
+    "icon": "moon-waning-crescent-6"
+  },
+
+  "moon-alt-new": {
+    "label": "moon-alt-new",
+    "icon": "moon-alt-new"
+  },
+
+  "moon-alt-waxing-crescent-1": {
+    "label": "moon-alt-waxing-crescent-1",
+    "icon": "moon-alt-waxing-crescent-1"
+  },
+
+  "moon-alt-waxing-crescent-2": {
+    "label": "moon-alt-waxing-crescent-2",
+    "icon": "moon-alt-waxing-crescent-2"
+  },
+
+  "moon-alt-waxing-crescent-3": {
+    "label": "moon-alt-waxing-crescent-3",
+    "icon": "moon-alt-waxing-crescent-3"
+  },
+
+  "moon-alt-waxing-crescent-4": {
+    "label": "moon-alt-waxing-crescent-4",
+    "icon": "moon-alt-waxing-crescent-4"
+  },
+
+  "moon-alt-waxing-crescent-5": {
+    "label": "moon-alt-waxing-crescent-5",
+    "icon": "moon-alt-waxing-crescent-5"
+  },
+
+  "moon-alt-waxing-crescent-6": {
+    "label": "moon-alt-waxing-crescent-6",
+    "icon": "moon-alt-waxing-crescent-6"
+  },
+
+  "moon-alt-first-quarter": {
+    "label": "moon-alt-first-quarter",
+    "icon": "moon-alt-first-quarter"
+  },
+
+  "moon-alt-waxing-gibbous-1": {
+    "label": "moon-alt-waxing-gibbous-1",
+    "icon": "moon-alt-waxing-gibbous-1"
+  },
+
+  "moon-alt-waxing-gibbous-2": {
+    "label": "moon-alt-waxing-gibbous-2",
+    "icon": "moon-alt-waxing-gibbous-2"
+  },
+
+  "moon-alt-waxing-gibbous-3": {
+    "label": "moon-alt-waxing-gibbous-3",
+    "icon": "moon-alt-waxing-gibbous-3"
+  },
+
+  "moon-alt-waxing-gibbous-4": {
+    "label": "moon-alt-waxing-gibbous-4",
+    "icon": "moon-alt-waxing-gibbous-4"
+  },
+
+  "moon-alt-waxing-gibbous-5": {
+    "label": "moon-alt-waxing-gibbous-5",
+    "icon": "moon-alt-waxing-gibbous-5"
+  },
+
+  "moon-alt-waxing-gibbous-6": {
+    "label": "moon-alt-waxing-gibbous-6",
+    "icon": "moon-alt-waxing-gibbous-6"
+  },
+
+  "moon-alt-full": {
+    "label": "moon-alt-full",
+    "icon": "moon-alt-full"
+  },
+
+  "moon-alt-waning-gibbous-1": {
+    "label": "moon-alt-waning-gibbous-1",
+    "icon": "moon-alt-waning-gibbous-1"
+  },
+
+  "moon-alt-waning-gibbous-2": {
+    "label": "moon-alt-waning-gibbous-2",
+    "icon": "moon-alt-waning-gibbous-2"
+  },
+
+  "moon-alt-waning-gibbous-3": {
+    "label": "moon-alt-waning-gibbous-3",
+    "icon": "moon-alt-waning-gibbous-3"
+  },
+
+  "moon-alt-waning-gibbous-4": {
+    "label": "moon-alt-waning-gibbous-4",
+    "icon": "moon-alt-waning-gibbous-4"
+  },
+
+  "moon-alt-waning-gibbous-5": {
+    "label": "moon-alt-waning-gibbous-5",
+    "icon": "moon-alt-waning-gibbous-5"
+  },
+
+  "moon-alt-waning-gibbous-6": {
+    "label": "moon-alt-waning-gibbous-6",
+    "icon": "moon-alt-waning-gibbous-6"
+  },
+
+  "moon-alt-third-quarter": {
+    "label": "moon-alt-third-quarter",
+    "icon": "moon-alt-third-quarter"
+  },
+
+  "moon-alt-waning-crescent-1": {
+    "label": "moon-alt-waning-crescent-1",
+    "icon": "moon-alt-waning-crescent-1"
+  },
+
+  "moon-alt-waning-crescent-2": {
+    "label": "moon-alt-waning-crescent-2",
+    "icon": "moon-alt-waning-crescent-2"
+  },
+
+  "moon-alt-waning-crescent-3": {
+    "label": "moon-alt-waning-crescent-3",
+    "icon": "moon-alt-waning-crescent-3"
+  },
+
+  "moon-alt-waning-crescent-4": {
+    "label": "moon-alt-waning-crescent-4",
+    "icon": "moon-alt-waning-crescent-4"
+  },
+
+  "moon-alt-waning-crescent-5": {
+    "label": "moon-alt-waning-crescent-5",
+    "icon": "moon-alt-waning-crescent-5"
+  },
+
+  "moon-alt-waning-crescent-6": {
+    "label": "moon-alt-waning-crescent-6",
+    "icon": "moon-alt-waning-crescent-6"
+  },
+
+  "moon-0": {
+    "label": "moon-0",
+    "icon": "moon-0"
+  },
+
+  "moon-1": {
+    "label": "moon-1",
+    "icon": "moon-1"
+  },
+
+  "moon-2": {
+    "label": "moon-2",
+    "icon": "moon-2"
+  },
+
+  "moon-3": {
+    "label": "moon-3",
+    "icon": "moon-3"
+  },
+
+  "moon-4": {
+    "label": "moon-4",
+    "icon": "moon-4"
+  },
+
+  "moon-5": {
+    "label": "moon-5",
+    "icon": "moon-5"
+  },
+
+  "moon-6": {
+    "label": "moon-6",
+    "icon": "moon-6"
+  },
+
+  "moon-7": {
+    "label": "moon-7",
+    "icon": "moon-7"
+  },
+
+  "moon-8": {
+    "label": "moon-8",
+    "icon": "moon-8"
+  },
+
+  "moon-9": {
+    "label": "moon-9",
+    "icon": "moon-9"
+  },
+
+  "moon-10": {
+    "label": "moon-10",
+    "icon": "moon-10"
+  },
+
+  "moon-11": {
+    "label": "moon-11",
+    "icon": "moon-11"
+  },
+
+  "moon-12": {
+    "label": "moon-12",
+    "icon": "moon-12"
+  },
+
+  "moon-13": {
+    "label": "moon-13",
+    "icon": "moon-13"
+  },
+
+  "moon-14": {
+    "label": "moon-14",
+    "icon": "moon-14"
+  },
+
+  "moon-15": {
+    "label": "moon-15",
+    "icon": "moon-15"
+  },
+
+  "moon-16": {
+    "label": "moon-16",
+    "icon": "moon-16"
+  },
+
+  "moon-17": {
+    "label": "moon-17",
+    "icon": "moon-17"
+  },
+
+  "moon-18": {
+    "label": "moon-18",
+    "icon": "moon-18"
+  },
+
+  "moon-19": {
+    "label": "moon-19",
+    "icon": "moon-19"
+  },
+
+  "moon-20": {
+    "label": "moon-20",
+    "icon": "moon-20"
+  },
+
+  "moon-21": {
+    "label": "moon-21",
+    "icon": "moon-21"
+  },
+
+  "moon-22": {
+    "label": "moon-22",
+    "icon": "moon-22"
+  },
+
+  "moon-23": {
+    "label": "moon-23",
+    "icon": "moon-23"
+  },
+
+  "moon-24": {
+    "label": "moon-24",
+    "icon": "moon-24"
+  },
+
+  "moon-25": {
+    "label": "moon-25",
+    "icon": "moon-25"
+  },
+
+  "moon-26": {
+    "label": "moon-26",
+    "icon": "moon-26"
+  },
+
+  "moon-27": {
+    "label": "moon-27",
+    "icon": "moon-27"
+  },
+
+  "time-1": {
+    "label": "time-1",
+    "icon": "time-1"
+  },
+
+  "time-2": {
+    "label": "time-2",
+    "icon": "time-2"
+  },
+
+  "time-3": {
+    "label": "time-3",
+    "icon": "time-3"
+  },
+
+  "time-4": {
+    "label": "time-4",
+    "icon": "time-4"
+  },
+
+  "time-5": {
+    "label": "time-5",
+    "icon": "time-5"
+  },
+
+  "time-6": {
+    "label": "time-6",
+    "icon": "time-6"
+  },
+
+  "time-7": {
+    "label": "time-7",
+    "icon": "time-7"
+  },
+
+  "time-8": {
+    "label": "time-8",
+    "icon": "time-8"
+  },
+
+  "time-9": {
+    "label": "time-9",
+    "icon": "time-9"
+  },
+
+  "time-10": {
+    "label": "time-10",
+    "icon": "time-10"
+  },
+
+  "time-11": {
+    "label": "time-11",
+    "icon": "time-11"
+  },
+
+  "time-12": {
+    "label": "time-12",
+    "icon": "time-12"
+  },
+
+  "direction-up": {
+    "label": "direction-up",
+    "icon": "direction-up"
+  },
+
+  "direction-up-right": {
+    "label": "direction-up-right",
+    "icon": "direction-up-right"
+  },
+
+  "direction-right": {
+    "label": "direction-right",
+    "icon": "direction-right"
+  },
+
+  "direction-down-right": {
+    "label": "direction-down-right",
+    "icon": "direction-down-right"
+  },
+
+  "direction-down": {
+    "label": "direction-down",
+    "icon": "direction-down"
+  },
+
+  "direction-down-left": {
+    "label": "direction-down-left",
+    "icon": "direction-down-left"
+  },
+
+  "direction-left": {
+    "label": "direction-left",
+    "icon": "direction-left"
+  },
+
+  "direction-up-left": {
+    "label": "direction-up-left",
+    "icon": "direction-up-left"
+  },
+
+  "wind-beaufort-0": {
+    "label": "wind-beaufort-0",
+    "icon": "wind-beaufort-0"
+  },
+
+  "wind-beaufort-1": {
+    "label": "wind-beaufort-1",
+    "icon": "wind-beaufort-1"
+  },
+
+  "wind-beaufort-2": {
+    "label": "wind-beaufort-2",
+    "icon": "wind-beaufort-2"
+  },
+
+  "wind-beaufort-3": {
+    "label": "wind-beaufort-3",
+    "icon": "wind-beaufort-3"
+  },
+
+  "wind-beaufort-4": {
+    "label": "wind-beaufort-4",
+    "icon": "wind-beaufort-4"
+  },
+
+  "wind-beaufort-5": {
+    "label": "wind-beaufort-5",
+    "icon": "wind-beaufort-5"
+  },
+
+  "wind-beaufort-6": {
+    "label": "wind-beaufort-6",
+    "icon": "wind-beaufort-6"
+  },
+
+  "wind-beaufort-7": {
+    "label": "wind-beaufort-7",
+    "icon": "wind-beaufort-7"
+  },
+
+  "wind-beaufort-8": {
+    "label": "wind-beaufort-8",
+    "icon": "wind-beaufort-8"
+  },
+
+  "wind-beaufort-9": {
+    "label": "wind-beaufort-9",
+    "icon": "wind-beaufort-9"
+  },
+
+  "wind-beaufort-10": {
+    "label": "wind-beaufort-10",
+    "icon": "wind-beaufort-10"
+  },
+
+  "wind-beaufort-11": {
+    "label": "wind-beaufort-11",
+    "icon": "wind-beaufort-11"
+  },
+
+  "wind-beaufort-12": {
+    "label": "wind-beaufort-12",
+    "icon": "wind-beaufort-12"
+  }
+}

--- a/src/utils/maps/index.js
+++ b/src/utils/maps/index.js
@@ -1,5 +1,6 @@
+import * as defaultIcons from './default-weather-icons.json';
 import * as owmIcons from './owm-weather-icons.json';
 import * as yahooIcons from './yahoo-weather-icons.json';
 import * as darkSkyIcons from './darksky-weather-icons.json';
 
-export { owmIcons, yahooIcons, darkSkyIcons };
+export { defaultIcons, owmIcons, yahooIcons, darkSkyIcons };

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,18 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('WeatherIcon', () => {
 
+  describe('default component', () => {
+    let wrapper;
+    it('should have name def', () => {
+      wrapper = shallow(<WeatherIcon name='def' iconId="celsius" />);
+      expect(wrapper.props().name).to.equal('def');
+    });
+    it('should map appropriate className with ID celsius for def', () => {
+      wrapper = shallow(<WeatherIcon name='def' iconId="celsius" />);
+      expect(wrapper.props().className).to.equal('wi wi-celsius');
+    });
+  });
+
   describe('open weather map component', () => {
     let wrapper;
     it('should have name owm', () => {
@@ -15,7 +27,6 @@ describe('WeatherIcon', () => {
       expect(wrapper.props().name).to.equal('owm');
     });
     it('should map appropriate className with ID 200 for owm', () => {
-
       wrapper = shallow(<WeatherIcon name='owm' iconId="200" />);
       expect(wrapper.props().className).to.equal('wi wi-day-storm-showers');
     });
@@ -28,7 +39,6 @@ describe('WeatherIcon', () => {
       expect(wrapper.props().name).to.equal('yahoo');
     });
     it('should map appropriate className with ID 0 for yahoo', () => {
-
       wrapper = shallow(<WeatherIcon name='yahoo' iconId='0' />);
       expect(wrapper.props().className).to.equal('wi wi-yahoo-0');
     });


### PR DESCRIPTION
This library is really useful ! Thanks a lot @williamsb 🥇 
I just lacked the support of miscellaneous icons such a celsius or fahrenheit.
With this fork, you can use them using the following synthax : 

```js
<WeatherIcon name='def' iconId="celsius" />
```

("def" stands for default).